### PR TITLE
update to java 17

### DIFF
--- a/check_version.sh
+++ b/check_version.sh
@@ -6,7 +6,7 @@ readonly JSON=`cat docker/image_name.json`
 readonly IMAGE_NAME="${BASH_REMATCH[1]}"
 
 readonly MY_DIR="$( cd "$( dirname "${0}" )" && pwd )"
-readonly EXPECTED=15
+readonly EXPECTED=17
 readonly ACTUAL=$(docker run --rm -it ${IMAGE_NAME} sh -c 'javac -version 2>&1')
 
 if echo "${ACTUAL}" | grep -q "${EXPECTED}"; then

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,2 +1,2 @@
-FROM bellsoft/liberica-openjdk-alpine-musl:15
+FROM bellsoft/liberica-openjdk-alpine-musl:17
 LABEL maintainer=jon@jaggersoft.com

--- a/docker/image_name.json
+++ b/docker/image_name.json
@@ -1,3 +1,3 @@
 {
-  "image_name": "cyberdojofoundation/java-15"
+  "image_name": "cyberdojofoundation/java-17"
 }


### PR DESCRIPTION
The change create a docker image language image for java version 17.
When merged a new docker image is created with the image name `cyberdojofoundation/java-17 `.